### PR TITLE
opentelemetry-instrumentation-fastapi 0.59b0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,10 @@ test:
     - opentelemetry.instrumentation.fastapi
   requires:
     - pip
+    # fastapi is imported at module level in
+    # opentelemetry/instrumentation/fastapi/__init__.py; needed for
+    # the import test even though it's only in run_constrained.
+    - fastapi >=0.92,<1
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,46 +1,56 @@
 {% set name = "opentelemetry-instrumentation-fastapi" %}
-{% set version = "0.36b0" %}
+{% set version = "0.59b0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_instrumentation_fastapi-{{ version }}.tar.gz
-  sha256: 3dc7b1af7e268faeecbde220ffab1502dff1680bd9459216fdf28166fed17f14
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_instrumentation_fastapi-{{ version }}.tar.gz
+  sha256: e8fe620cfcca96a7d634003df1bc36a42369dedcdd6893e13fb5903aeeb89b2b
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  skip: true  # [py<310]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - hatchling
   run:
-    - python >=3.7
-    - opentelemetry-api >=1.12,<2.dev0
-    - opentelemetry-instrumentation-asgi ==0.36b0
-    - opentelemetry-instrumentation ==0.36b0
-    - opentelemetry-semantic-conventions ==0.36b0
-    - opentelemetry-util-http ==0.36b0
+    - python
+    - opentelemetry-api >=1.12,<2
+    - opentelemetry-instrumentation ==0.59b0
+    - opentelemetry-instrumentation-asgi ==0.59b0
+    - opentelemetry-semantic-conventions ==0.59b0
+    - opentelemetry-util-http ==0.59b0
+  run_constrained:
+    - fastapi >=0.92,<1
 
 test:
   imports:
     - opentelemetry
-    - opentelemetry.instrumentation
-  commands:
-    - pip check
+    - opentelemetry.instrumentation.fastapi
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-fastapi
   summary: OpenTelemetry FastAPI Instrumentation
+  description: |
+    OpenTelemetry instrumentation for FastAPI applications. Wraps a FastAPI
+    ASGI app to automatically generate spans for incoming requests,
+    propagate trace context, and emit standard HTTP semantic-convention
+    attributes. Built on top of opentelemetry-instrumentation-asgi.
   license: Apache-2.0
+  license_family: APACHE
   license_file: LICENSE
+  doc_url: https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/fastapi/fastapi.html
+  dev_url: https://github.com/open-telemetry/opentelemetry-python-contrib
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
opentelemetry-instrumentation-fastapi 0.59b0

**Destination channel:** defaults

### Links

- [PKG-14500](https://anaconda.atlassian.net/browse/PKG-14500) (blocks PKG-7382 chromadb)
- [Upstream repository](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-fastapi)
- Conda-forge recipe: https://github.com/conda-forge/opentelemetry-instrumentation-fastapi-feedstock/blob/main/recipe/meta.yaml
- Sibling dependency PR: AnacondaRecipes/opentelemetry-instrumentation-asgi-feedstock#3 (merged + released)

### Explanation of changes:

- **First release of `opentelemetry-instrumentation-fastapi` to pkgs/main.** AnacondaRecipes fork was at v0.36b0 (very stale) and never released. Required by chromadb 1.5.8 (PKG-7382), where `chromadb/telemetry/opentelemetry/fastapi.py` does `from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor`.
- **Version 0.36b0 → 0.59b0** to match the OpenTelemetry Python Contrib suite already on pkgs/main:
  - `opentelemetry-instrumentation 0.59b0`
  - `opentelemetry-instrumentation-asgi 0.59b0` (just released as PKG-14504)
  - `opentelemetry-semantic-conventions 0.59b0`
  - `opentelemetry-util-http 0.59b0`

  Going to the latest `0.62b1` would force bumping all of those siblings together (synchronized monorepo release with `==X.YYbN` cross-pins).
- **Adaptations:**
  - Drop `noarch: python`; build per-Python with `skip: true  # [py<310]` to match the AnacondaRecipes Python matrix.
  - Translate PEP 440 `~=1.12` specifier to explicit `>=1.12,<2` form (conda doesn't natively understand `~=`).
  - Add `fastapi >=0.92,<1` in `run_constrained` per upstream's `instruments` optional extra (`fastapi~=0.92`); FastAPI is the package this plugin instruments, but isn't a hard runtime dep.
  - Modern install flags: `--no-deps --no-build-isolation`.
  - More precise test import: `opentelemetry.instrumentation.fastapi` (the actual instrumentation module, not just the parent namespace).
  - Switch `pypi.io` → `pypi.org`.
  - Complete `about` section: add `description`, `doc_url`, `dev_url`, `license_family`.
- **Upstream-verified deps:** [`pyproject.toml`](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/v1.38.0/instrumentation/opentelemetry-instrumentation-fastapi/pyproject.toml) declares hatchling backend (no separate `wheel` needed) and runtime deps `opentelemetry-api~=1.12` plus `==0.59b0` pins on four sibling packages, with `fastapi~=0.92` only in the `instruments` extra.

[PKG-14500]: https://anaconda.atlassian.net/browse/PKG-14500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ